### PR TITLE
Pull request for  #8: Error in applying plugin from a shared script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - echo "skip default gradlew assemble"
 script:
 #  - ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace || true'
-  - '[ "${TRAVIS_PULL_REQUEST}" = "true" ] && ./gradlew test --info --stacktrace || true'
+#  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace || true'
+  - './gradlew test --info --stacktrace'
 after_success:
   - ./gradlew coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 install:
   - echo "skip default gradlew assemble"
 script:
-- [ "${TRAVIS_PULL_REQUEST}" = "false" ] && ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace || ./gradlew build cobertura --info --stacktrace
+- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace || ./gradlew build cobertura --info --stacktrace'
 
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - echo "skip default gradlew assemble"
 script:
 #  - ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace'
-  - '[ "${TRAVIS_PULL_REQUEST}" = "true" ] && ./gradlew test --info --stacktrace'
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace || true'
+  - '[ "${TRAVIS_PULL_REQUEST}" = "true" ] && ./gradlew test --info --stacktrace || true'
 after_success:
   - ./gradlew coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_install:
 install:
   - echo "skip default gradlew assemble"
 script:
-#  - ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace
-#  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace || true'
-  - './gradlew test --info --stacktrace'
+- [ "${TRAVIS_PULL_REQUEST}" = "false" ] && ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace || ./gradlew build cobertura --info --stacktrace
+
+
 after_success:
   - ./gradlew coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_install:
 install:
   - echo "skip default gradlew assemble"
 script:
-  - ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace
+#  - ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ./gradlew release cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password -Dgradle.publish.key=${GRADLE_KEY} -Dgradle.publish.secret=${GRADLE_SECRET} --info --stacktrace'
+  - '[ "${TRAVIS_PULL_REQUEST}" = "true" ] && ./gradlew test --info --stacktrace'
 after_success:
   - ./gradlew coveralls

--- a/src/main/groovy/de/gliderpilot/gradle/semanticrelease/SemanticReleasePlugin.groovy
+++ b/src/main/groovy/de/gliderpilot/gradle/semanticrelease/SemanticReleasePlugin.groovy
@@ -23,8 +23,8 @@ class SemanticReleasePlugin implements Plugin<Project> {
 
     void apply(Project project) {
         project.with {
-            plugins.apply('org.ajoberstar.grgit')
-            plugins.apply('org.ajoberstar.release-base')
+            plugins.apply(org.ajoberstar.gradle.git.base.GrgitPlugin)
+            plugins.apply(org.ajoberstar.gradle.git.release.base.BaseReleasePlugin)
             SemanticReleasePluginExtension semanticReleaseExtension = extensions.create("semanticRelease", SemanticReleasePluginExtension, project)
             ReleasePluginExtension releaseExtension = extensions.findByType(ReleasePluginExtension)
             tasks.release.doLast {

--- a/src/test/groovy/de/gliderpilot/gradle/semanticrelease/SemanticReleasePluginIntegrationSpec.groovy
+++ b/src/test/groovy/de/gliderpilot/gradle/semanticrelease/SemanticReleasePluginIntegrationSpec.groovy
@@ -261,22 +261,45 @@ class SemanticReleasePluginIntegrationSpec extends IntegrationSpec {
         thrown(RuntimeException)
     }
 
+
+    def executeOnWindows(File workingDir, String... command) {
+        def lastLine
+        def process = new ProcessBuilder(command)
+                .directory(workingDir)
+                .redirectErrorStream(true)
+                .start()
+        process.inputStream.eachLine {
+            println it
+            lastLine = it
+        }
+
+        def exitValue = process.exitValue()
+        if(exitValue != 0)
+            throw new RuntimeException("failed to execute ${command.join(' ')}")
+        return lastLine
+
+    }
+
     def execute(File dir = projectDir, String... args) {
         println "========"
         println "executing ${args.join(' ')}"
         println "--------"
-        def process = args.execute(null, dir)
-        String processOut = process.inputStream.text.trim()
-        String processErr = process.errorStream.text.trim()
-        println processOut
-        println processErr
-        if (process.waitFor() != 0)
-            throw new RuntimeException("failed to execute ${args.join(' ')}")
-        return processOut
+        if(isWindows())
+            executeOnWindows(dir, args)
+        else{
+            def process = args.execute(null, dir)
+            String processOut = process.inputStream.text.trim()
+            String processErr = process.errorStream.text.trim()
+            println processOut
+            println processErr
+            if (process.waitFor() != 0)
+                throw new RuntimeException("failed to execute ${args.join(' ')}")
+            return processOut
+        }
     }
 
     def release() {
-        execute './gradlew', '-I', '.gradle-test-kit/init.gradle', 'release', '--info', '--stacktrace'
+        execute "./gradlew${isWindows()?'.bat':''}", '-I', '.gradle-test-kit/init.gradle', 'release', '--info', '--stacktrace'
         lastVersion()
     }
 
@@ -291,7 +314,7 @@ class SemanticReleasePluginIntegrationSpec extends IntegrationSpec {
 
     def commit(message) {
         execute 'git', 'add', '.'
-        execute 'git', 'commit', '--allow-empty', '--allow-empty-message', '-m', message
+        execute 'git', 'commit', '--allow-empty', '--allow-empty-message', '-m', message?:"''"
     }
 
     def push() {
@@ -306,4 +329,9 @@ class SemanticReleasePluginIntegrationSpec extends IntegrationSpec {
     def checkout(String branch) {
         execute "git", "checkout", branch
     }
+
+    boolean isWindows(){
+        System.properties['os.name'].toLowerCase().contains('windows')
+    }
+
 }

--- a/src/test/groovy/de/gliderpilot/gradle/semanticrelease/SemanticReleasePluginIntegrationSpec.groovy
+++ b/src/test/groovy/de/gliderpilot/gradle/semanticrelease/SemanticReleasePluginIntegrationSpec.groovy
@@ -36,7 +36,7 @@ class SemanticReleasePluginIntegrationSpec extends IntegrationSpec {
         push()
     }
 
-    private File setupGitignore() {
+    def setupGitignore() {
         file('.gitignore') << '''\
             .gradle-test-kit/
             .gradle/
@@ -46,14 +46,14 @@ class SemanticReleasePluginIntegrationSpec extends IntegrationSpec {
         '''.stripIndent()
     }
 
-    private File setupGradleProject() {
+    def setupGradleProject() {
         buildFile << '''
             apply plugin: 'de.gliderpilot.semantic-release'
             println version
         '''
     }
 
-    private void setupGit() {
+    def setupGit() {
 // create remote repository
         File origin = new File(projectDir, "../${projectDir.name}.git")
         origin.mkdir()

--- a/src/test/groovy/de/gliderpilot/gradle/semanticrelease/SemanticReleasePluginIntegrationSpec.groovy
+++ b/src/test/groovy/de/gliderpilot/gradle/semanticrelease/SemanticReleasePluginIntegrationSpec.groovy
@@ -28,7 +28,33 @@ import spock.lang.Unroll
 class SemanticReleasePluginIntegrationSpec extends IntegrationSpec {
 
     def setup() {
-        // create remote repository
+        setupGit()
+        setupGradleProject()
+        setupGitignore()
+        runTasksSuccessfully(':wrapper')
+        commit('initial project layout')
+        push()
+    }
+
+    private File setupGitignore() {
+        file('.gitignore') << '''\
+            .gradle-test-kit/
+            .gradle/
+            gradle/
+            build/
+            cobertura.ser
+        '''.stripIndent()
+    }
+
+    private File setupGradleProject() {
+        buildFile << '''
+            apply plugin: 'de.gliderpilot.semantic-release'
+            println version
+        '''
+    }
+
+    private void setupGit() {
+// create remote repository
         File origin = new File(projectDir, "../${projectDir.name}.git")
         origin.mkdir()
         execute origin, 'git', 'init', '--bare'
@@ -41,23 +67,6 @@ class SemanticReleasePluginIntegrationSpec extends IntegrationSpec {
 
         execute 'git', 'remote', 'add', 'origin', "$origin"
         commit 'initial commit'
-        push()
-
-        buildFile << '''
-            apply plugin: 'de.gliderpilot.semantic-release'
-            println version
-        '''
-        file('.gitignore') << '''\
-            .gradle-test-kit/
-            .gradle/
-            gradle/
-            build/
-            cobertura.ser
-        '''.stripIndent()
-
-        runTasksSuccessfully(':wrapper')
-
-        commit('initial project layout')
         push()
     }
 

--- a/src/test/groovy/de/gliderpilot/gradle/semanticrelease/integration/SemanticReleaseIntegrationAuxScriptSpec.groovy
+++ b/src/test/groovy/de/gliderpilot/gradle/semanticrelease/integration/SemanticReleaseIntegrationAuxScriptSpec.groovy
@@ -14,8 +14,6 @@ class SemanticReleaseIntegrationAuxScriptSpec extends SemanticReleasePluginInteg
             apply from:'release.gradle'
             println version
         '''
-        setupGitignore()
-
         file('release.gradle') << """
             buildscript{
 
@@ -35,8 +33,7 @@ class SemanticReleaseIntegrationAuxScriptSpec extends SemanticReleasePluginInteg
             apply plugin: de.gliderpilot.gradle.semanticrelease.SemanticReleasePlugin
 
 """
-        runTasksSuccessfully(':wrapper')
-    }
+}
 
     def getPluginCompileDir(){
         URL url=SemanticReleasePlugin.class.getResource(SemanticReleasePlugin.class.getSimpleName() + ".class")

--- a/src/test/groovy/de/gliderpilot/gradle/semanticrelease/integration/SemanticReleaseIntegrationAuxScriptSpec.groovy
+++ b/src/test/groovy/de/gliderpilot/gradle/semanticrelease/integration/SemanticReleaseIntegrationAuxScriptSpec.groovy
@@ -1,0 +1,49 @@
+package de.gliderpilot.gradle.semanticrelease.integration
+
+import de.gliderpilot.gradle.semanticrelease.SemanticReleasePlugin
+import de.gliderpilot.gradle.semanticrelease.SemanticReleasePluginIntegrationSpec
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+import spock.lang.Specification
+
+class SemanticReleaseIntegrationAuxScriptSpec extends SemanticReleasePluginIntegrationSpec {
+
+    @Override
+    void setupGradleProject(){
+        buildFile << '''
+            apply from:'release.gradle'
+            println version
+        '''
+        setupGitignore()
+
+        file('release.gradle') << """
+            buildscript{
+
+                repositories{
+                    jcenter()
+                }
+
+                dependencies{
+                    classpath files('${getPluginCompileDir()}')
+                    classpath files('${getPluginCompileDir().replace('/classes/','/resources/')}')
+                    classpath "org.ajoberstar:gradle-git:1.3.0"
+                    classpath 'com.jcabi:jcabi-github:0.23'
+                }
+
+            }
+
+            apply plugin: de.gliderpilot.gradle.semanticrelease.SemanticReleasePlugin
+
+"""
+        runTasksSuccessfully(':wrapper')
+    }
+
+    def getPluginCompileDir(){
+        URL url=SemanticReleasePlugin.class.getResource(SemanticReleasePlugin.class.getSimpleName() + ".class")
+        String classFilePath=new File(url.toURI()).absolutePath
+        if(isWindows())
+            classFilePath = classFilePath.replace('\\','/')
+        String classFileRelative = SemanticReleasePlugin.class.getName().replace('.', '/') + ".class"
+        classFilePath-classFileRelative
+    }
+}

--- a/src/test/groovy/de/gliderpilot/gradle/semanticrelease/integration/SemanticReleaseIntegrationAuxScriptSpec.groovy
+++ b/src/test/groovy/de/gliderpilot/gradle/semanticrelease/integration/SemanticReleaseIntegrationAuxScriptSpec.groovy
@@ -9,7 +9,7 @@ import spock.lang.Specification
 class SemanticReleaseIntegrationAuxScriptSpec extends SemanticReleasePluginIntegrationSpec {
 
     @Override
-    void setupGradleProject(){
+    def setupGradleProject(){
         buildFile << '''
             apply from:'release.gradle'
             println version


### PR DESCRIPTION
Hi,
here are the proposed changes to allow plugin application from an external gradle script.
Changes in main directory are quite straightforward, I just applied the plugins by full qualified name.
I needed more changes in the test directory, also because I develop on Windows, so I had to introduce some variants on process execution, depending on the actual os where the build is run.
