### PR TITLE
This should fix the error in master build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
 apply from: 'compile-dependencies.gradle'
 
 dependencies {
-    testCompile 'com.netflix.nebula:nebula-test:2.2.2', {
+    testCompile 'com.netflix.nebula:nebula-test:3.1.0', {
         exclude module: 'groovy-all'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip

--- a/src/test/groovy/de/gliderpilot/gradle/semanticrelease/integration/SemanticReleaseIntegrationAuxScriptSpec.groovy
+++ b/src/test/groovy/de/gliderpilot/gradle/semanticrelease/integration/SemanticReleaseIntegrationAuxScriptSpec.groovy
@@ -22,8 +22,7 @@ class SemanticReleaseIntegrationAuxScriptSpec extends SemanticReleasePluginInteg
                 }
 
                 dependencies{
-                    classpath files('${getPluginCompileDir()}')
-                    classpath files('${getPluginCompileDir().replace('/classes/','/resources/')}')
+                    classpath files('../../../classes/main')
                     classpath "org.ajoberstar:gradle-git:1.3.0"
                     classpath 'com.jcabi:jcabi-github:0.23'
                 }


### PR DESCRIPTION
When tests are run under cobertura, the `getPluginCompileDir()` gets the wrong path, as it seems to be 'instrumented_classes' instead of 'classes'. These _instrumented classes_ have a reference to cobertura, which is not in the classpath, when the applied gradle script is run.

I changed it with a simpler algorithm: as tests seem to run in a directory `build/test/<test class name>/<test method name>`, I just walked up the path to find 'classes/main'.

After that, tests were still failing, until I upgraded `nebula-test' to version 3.1.0, which in turn required me to [upgrade gradle version](https://github.com/nebula-plugins/nebula-test#gradle-compatibility-tested). 
